### PR TITLE
Changed RabbitMQ Hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-**Table of Contents**  _generated with [DocToc](https://github.com/thlorenz/doctoc)_
-
--   [Role Name](#role-name)
-    -   [Requirements](#requirements)
-    -   [Role Variables](#role-variables)
-    -   [Dependencies](#dependencies)
-        -   [Ansible Roles](#ansible-roles)
-    -   [Example Playbook](#example-playbook)
-    -   [License](#license)
-    -   [Author Information](#author-information)
+- [Role Name](#role-name)
+  - [Requirements](#requirements)
+  - [Role Variables](#role-variables)
+  - [Dependencies](#dependencies)
+    - [Ansible Roles](#ansible-roles)
+  - [Example Playbook](#example-playbook)
+  - [License](#license)
+  - [Author Information](#author-information)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -122,7 +120,8 @@ openstack_compute_service_compute_placement_user_info:
 openstack_compute_service_compute_placement_user_pass: []
 
 # RabbitMQ Connection Info
-openstack_compute_service_compute_rabbit_host: 'localhost'
+openstack_compute_service_compute_rabbit_hosts:
+  - 127.0.0.1
 openstack_compute_service_compute_rabbit_pass: 'openstack'
 openstack_compute_service_compute_rabbit_user: 'openstack'
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -94,6 +94,7 @@ openstack_compute_service_compute_placement_user_info:
 openstack_compute_service_compute_placement_user_pass: []
 
 # RabbitMQ Connection Info
-openstack_compute_service_compute_rabbit_host: 'localhost'
+openstack_compute_service_compute_rabbit_hosts:
+  - 127.0.0.1
 openstack_compute_service_compute_rabbit_pass: 'openstack'
 openstack_compute_service_compute_rabbit_user: 'openstack'

--- a/templates/etc/nova/nova.conf.j2
+++ b/templates/etc/nova/nova.conf.j2
@@ -9,7 +9,10 @@ force_dhcp_release=true
 log_dir=/var/log/nova
 my_ip = {{ openstack_compute_service_compute_management_ip }}
 state_path=/var/lib/nova
-transport_url = rabbit://{{ openstack_compute_service_compute_rabbit_user }}:{{ openstack_compute_service_compute_rabbit_pass }}@{{ openstack_compute_service_compute_rabbit_host }}
+{% set _rabbit_user = openstack_compute_service_compute_rabbit_user %}
+{% set _rabbit_pass = openstack_compute_service_compute_rabbit_pass %}
+transport_url = rabbit://{% for host in openstack_compute_service_compute_rabbit_hosts %}{{ _rabbit_user }}:{{ _rabbit_pass }}@{{ host }}{% if not loop.last %},{% endif %}{% endfor %}
+
 use_neutron = True
 
 [api]
@@ -154,7 +157,7 @@ username = {{ openstack_compute_service_compute_placement['username'] }}
 enabled = True
 novncproxy_base_url = {{ openstack_compute_service_compute_keystone_service_endpoint_url }}:6080/vnc_auto.html
 vncserver_listen = 0.0.0.0
-vncserver_proxyclient_address = $my_ip
+vncserver_proxyclient_address = {{ openstack_compute_service_compute_management_ip }}
 
 [workarounds]
 


### PR DESCRIPTION
Changed the openstack_networking_service_compute_rabbit_host variable to
openstack_networking_service_compute_rabbit_hosts to provide an array or
define a group.

Resolves #1

Signed-off-by: Larry Smith Jr <mrlesmithjr@gmail.com>